### PR TITLE
Add script to generate Xcode project

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,13 @@ Open WebUI iOS places a strong emphasis on security and privacy:
 - Swift 5.7+
 - Optional: Ollama instance on local network
 
+## Running in Xcode 🛠
+
+1. Execute `scripts/generate_xcode_project.sh` from the repository root. This
+   uses Swift Package Manager to create `OpenWebUIiOS.xcodeproj`.
+2. Open the generated project in Xcode.
+3. Choose a simulator or connected device and press **Run**.
+
 ## References 📚
 
 This project uses the original [Open WebUI](https://github.com/open-webui/open-webui) as a reference for design and functionality. The original Open WebUI documentation can be found in the [open-webui_docs](./open-webui_docs/) directory.

--- a/scripts/generate_xcode_project.sh
+++ b/scripts/generate_xcode_project.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Generate Xcode project for the OpenWebUI iOS application.
+# Requires Xcode with Swift Package Manager support.
+
+set -euo pipefail
+
+# Determine repository root
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+APP_DIR="$REPO_ROOT/OpenWebUIiOS"
+
+cd "$APP_DIR"
+
+# Use Swift Package Manager to generate the project
+swift package generate-xcodeproj
+
+echo "Generated OpenWebUIiOS.xcodeproj inside $APP_DIR"


### PR DESCRIPTION
## Summary
- add script `scripts/generate_xcode_project.sh` to create an Xcode project for the iOS app
- document how to run the script in README

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/raspu/Highlightr)*