### PR TITLE
Fix typos in ElasticsearchClient docstring

### DIFF
--- a/backend/open_webui/retrieval/vector/dbs/elasticsearch.py
+++ b/backend/open_webui/retrieval/vector/dbs/elasticsearch.py
@@ -24,8 +24,8 @@ class ElasticsearchClient(VectorDBBase):
     """
     Important:
     in order to reduce the number of indexes and since the embedding vector length is fixed, we avoid creating
-    an index for each file but store it as a text field, while seperating to different index
-    baesd on the embedding length.
+    an index for each file but store it as a text field, while separating to different index
+    based on the embedding length.
     """
 
     def __init__(self):


### PR DESCRIPTION
## Summary
- fix spelling errors in `ElasticsearchClient` class docstring

## Testing
- `python3 -m py_compile backend/open_webui/retrieval/vector/dbs/elasticsearch.py`