### PR TITLE
remove unused notification permission key

### DIFF
--- a/OpenWebUIiOS/Info.plist
+++ b/OpenWebUIiOS/Info.plist
@@ -64,7 +64,5 @@
         <string>com.openwebui.ios.messageProcessing</string>
         <string>com.openwebui.ios.messageCompletion</string>
     </array>
-    <key>NSUserNotificationsUsageDescription</key>
-    <string>Open WebUI would like to send you notifications when your AI responses are completed in the background.</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- remove incorrect `NSUserNotificationsUsageDescription` entry from Info.plist

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run test:frontend` *(fails: vitest not found)*
- `pytest --maxfail=1 -q` *(fails: command not found)*
